### PR TITLE
fix: correct branch reference condition in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:     
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'master' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.ref == 'refs/heads/master' }}
     name: Deploy
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request includes a minor update to the deployment workflow configuration. The conditional for triggering the deploy job has been updated to use `github.ref == 'refs/heads/master'` instead of checking `github.event.workflow_run.head_branch == 'master'`. This change ensures more reliable detection of pushes to the master branch.